### PR TITLE
Check for truthy pose values

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = function(THREE, packageRoot) {
             requestAnimationFrame(update);
 
             var gamepad = navigator.getGamepads()[controllerId];
-            if (gamepad && gamepad.pose !== null) {
+            if (gamepad && gamepad.pose) {
                 c.visible = true;
 
                 var padButton = gamepad.buttons[0]

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = function(THREE, packageRoot) {
 
                 var pose = gamepad.pose;
 
-                if(pose.position != null && pose.orientation != null) {
+                if(pose.position && pose.orientation) {
                     c.tracked = true
                     c.lastPosePosition = pose.position
                     c.lastPoseOrientation = pose.orientation


### PR DESCRIPTION
Hey, sorry for the inconvenience. That new Chrome also has a `gamepad.pose` value of undefined. This PR fixes the check for that.

Additionally I changed the checks for `pose.position` and `pose.orientation` for consistency.